### PR TITLE
prep_heroku CORS enabled and set to localhost by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,23 @@ tested:
 * node v12.18.2
 * npm v16.14.5
 
+# Client Configuration
+There should be no changes required for CORS if you are using the Apollo Client with **InMemoryCache enabled**. Just simply point to the server with settings like this (Angular pure client):
+```bash
+providers: [
+  {
+    provide: APOLLO_OPTIONS,
+    useFactory: (httpLink: HttpLink) => {
+      return {
+        cache: new InMemoryCache(),
+        link: httpLink.create({
+          uri: '/api/graphql'
+        })
+      };
+    },
+    deps: [HttpLink]
+  },
+  ```
+
 ### Author
 radkin@github.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "apolloserver-demo",
-  "version": "0.0.1",
+  "version": "1.0.0",
+  "private": true,
   "description": "apollo server basic demo implementation",
   "main": "index.js",
   "scripts": {
@@ -23,6 +24,9 @@
     "ioredis": "^4.14.1",
     "lorem-ipsum": "^2.0.3",
     "uuid": "^3.3.3"
+  },
+  "engines": {
+    "node": "12.x"
   },
   "devDependencies": {
     "ava": "^1.4.1",

--- a/server.js
+++ b/server.js
@@ -7,8 +7,23 @@ const LocationsAPI = require('./lib/datasources/locations-api');
 
 const Redis = require('ioredis'); //./lib/redis-client');
 const REDIS_SERVER = process.env.REDIS_SERVER || 'localhost';
+const CLIENT_HOST = process.env.CLIENT_HOST || 'localhost';
 const client = new Redis(6379, REDIS_SERVER);
 const server = new ApolloServer({
+  cors: {
+      credentials: true,
+      origin: (origin, callback) => {
+          const whitelist = [
+              `http://${CLIENT_HOST}`,
+          ];
+
+          if (whitelist.indexOf(origin) !== -1) {
+              callback(null, true)
+          } else {
+              callback(new Error("Not allowed by CORS"))
+          }
+      }
+  },
     typeDefs: schemas,
     resolvers,
     dataSources: () => {
@@ -23,7 +38,6 @@ const server = new ApolloServer({
       return { request: req, client }
     }
 });
-
 
 server.listen({ port:9000}).then(({ url }) => {
   console.log(`🚀 Server ready at ${url}`);


### PR DESCRIPTION
This will require an environment variable set in Heroku